### PR TITLE
Entering command in commandline and accessing previous command using … 

### DIFF
--- a/lcUILua/ui/commandline.lua
+++ b/lcUILua/ui/commandline.lua
@@ -30,7 +30,7 @@ end
 
 --Execute a command from command line
 function command(id, command)
-    commands[command:toStdString()](id)
+    commands[qt.QString.toStdString(command)](id)
 end
 
 --Store the point in memory when needed for relative coordinates


### PR DESCRIPTION
This was preventing text command from entering in commandline. Thus preventing the history to be recorded.
BTW commands activated using toolbar are not recorded in history. Has this been implemented? Any hints how to go about this?